### PR TITLE
fix: remove env for release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,7 +17,6 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: test
     steps:
       - name: release-please
         uses: google-github-actions/release-please-action@v3
@@ -27,7 +26,7 @@ jobs:
       - name: 'Remind to wait'
         uses: peter-evans/create-or-update-comment@v3
         with:
-          issue-number: ${{ steps.release-please.outputs.pr.number }}
+          issue-number: ${{ steps.release-please.outputs.pr }}
           body: |
             Please make sure e2e tests pass before approving PR!
 


### PR DESCRIPTION
since we are running e2e tests only after push to main we don't need the environment protections anymore