### PR TITLE
fix: remove version constraints

### DIFF
--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/byob/versions.tf
+++ b/examples/byob/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/candidate/versions.tf
+++ b/examples/candidate/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/cis/versions.tf
+++ b/examples/cis/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/latest/versions.tf
+++ b/examples/latest/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/manifest/versions.tf
+++ b/examples/manifest/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/nostart/versions.tf
+++ b/examples/nostart/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/reboot/versions.tf
+++ b/examples/reboot/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/examples/stable/versions.tf
+++ b/examples/stable/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5.0, < 1.6"
+  required_version = ">= 1.5.0"
   required_providers {
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
Don't constrain the Terraform version to only use the non BUSL versions.
Users are responsible for how they use our module and whether they are in compliance with their use of Terraform.